### PR TITLE
Chore clean up setup

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -3,41 +3,68 @@ on: push
 
 jobs:
   tests:
-    name: Code style and tests
     runs-on: ubuntu-latest
     strategy:
-      matrix:
-        php: [8.1, 8.2]
-        stability: ["--prefer-lowest", "--prefer-stable"]
+        fail-fast: true
+        matrix:
+          php: [ 8.1, 8.2, 8.3 ]
+          stability: [ prefer-lowest, prefer-stable ]
+          include:
+            - php: 8.1
+              stability: prefer-lowest
+              phpunit: 10
+            - php: 8.1
+              stability: prefer-stable
+              phpunit: 10
+            - php: 8.2
+              stability: prefer-lowest
+              phpunit: 10
+            - php: 8.2
+              stability: prefer-stable
+              phpunit: 10
+            - php: 8.3
+              stability: prefer-lowest
+              phpunit: 11
+            - php: 8.3
+              stability: prefer-stable
+              phpunit: 11
+    name: PHP ${{ matrix.php }} - ${{ matrix.stability }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          cache_dir=$(composer config cache-files-dir)
+          echo "dir=$cache_dir" >> $GITHUB_ENV
+
+      - name: Cache Dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.dir }}
+          key: ${{ runner.os }}-composer-php-${{ matrix.php }}-${{ hashFiles('**/composer.json') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: mbstring, dom, fileinfo
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, gd
           coverage: none
 
-      - name: Get composer cache directory
-        id: composer-cache
-        run: |
-          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      - name: Install dependencies
+        run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
-      - name: Cache composer dependencies
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-${{ matrix.php }}-${{ matrix.strategy }}-composer-${{ hashFiles('**/composer.json') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.php }}-${{ matrix.strategy }}-composer-
+      - name: Require specific versions of packages
+        run: composer update phpunit/phpunit:^${{ matrix.phpunit }} --dev -W
 
-      - name: Install Composer dependencies
-        run: composer update --no-interaction --no-progress --optimize-autoloader --prefer-dist ${{ matrix.stability }}
-
-      - name: Check code style
+      - name: Lint code
         run: composer lint
 
-      - name: Run tests
+      - name: Run PHPStan
+        run: composer phpstan
+
+      - name: Execute tests
         run: composer test

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 /vendor
 /*.cache
 composer.lock
-
+composer.phar
+.phpunit.cache
+.phpunit.result.cache
 /vendor/
 .idea/

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ composer.phar
 .phpunit.result.cache
 /vendor/
 .idea/
+vendor

--- a/composer.json
+++ b/composer.json
@@ -24,17 +24,19 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "php": "^8.0"
+        "php": "^8.1"
     },
     "require-dev": {
         "ext-json": "*",
-        "orchestra/testbench": "^8.0",
-        "phpunit/phpunit": "^9.6",
+        "phpstan/phpstan": "^1.11.8",
+        "phpunit/phpunit": "^10.0|^11.0",
         "squizlabs/php_codesniffer": "^3.6"
     },
     "scripts": {
         "check-code": [
-            "@test"
+            "@test",
+            "@lint",
+            "@phpstan"
         ],
         "lint": [
             "vendor/bin/phpcs --standard=PSR12 src/ tests/"
@@ -44,6 +46,9 @@
         ],
         "test": [
             "vendor/bin/phpunit"
+        ],
+        "phpstan": [
+            "vendor/bin/phpstan"
         ]
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,5 @@
+parameters:
+    level: 8
+    paths:
+        - src
+        - tests

--- a/src/Helpers/Helper.php
+++ b/src/Helpers/Helper.php
@@ -1,6 +1,7 @@
 <?php
+
 declare(strict_types=1);
-    
+
 namespace Biodun\PhpHelperMethods\Helpers;
 
 use DateInterval;
@@ -25,9 +26,9 @@ class Helper
         try {
             $date = new DateTime(timezone: $timeZone);
             if ($numberOfDays < 0) {
-                $date->sub(new DateInterval('P'.abs($numberOfDays).'D'));
+                $date->sub(new DateInterval('P' . abs($numberOfDays) . 'D'));
             } else {
-                $date->add(new DateInterval('P'.$numberOfDays.'D'));
+                $date->add(new DateInterval('P' . $numberOfDays . 'D'));
             }
 
             return $date->format($format);

--- a/src/Helpers/Helper.php
+++ b/src/Helpers/Helper.php
@@ -1,9 +1,12 @@
 <?php
+declare(strict_types=1);
+    
 namespace Biodun\PhpHelperMethods\Helpers;
 
 use DateInterval;
 use DateTime;
 use DateTimeZone;
+use Exception;
 
 class Helper
 {
@@ -11,9 +14,9 @@ class Helper
      * Add a number of days to the current date for a given timezone
      * Handles negative numbers as well
      *
-     * @param int $numberOfDays
-     * @param DateTimeZone|null $timeZone
-     * @param string $format
+     * @param  int  $numberOfDays
+     * @param  DateTimeZone|null  $timeZone
+     * @param  string  $format
      *
      * @return string|null
      */
@@ -22,9 +25,9 @@ class Helper
         try {
             $date = new DateTime(timezone: $timeZone);
             if ($numberOfDays < 0) {
-                $date->sub(new DateInterval('P' . abs($numberOfDays) . 'D'));
+                $date->sub(new DateInterval('P'.abs($numberOfDays).'D'));
             } else {
-                $date->add(new DateInterval('P' . $numberOfDays . 'D'));
+                $date->add(new DateInterval('P'.$numberOfDays.'D'));
             }
 
             return $date->format($format);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Biodun\PhpHelperMethods\Tests;
 
-abstract class TestCase extends \Orchestra\Testbench\TestCase
+use PHPUnit\Framework\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
 {
     //
 }

--- a/tests/Unit/AddDaysTest.php
+++ b/tests/Unit/AddDaysTest.php
@@ -7,21 +7,21 @@ use Biodun\PhpHelperMethods\Helpers\Helper;
 
 class AddDaysTest extends TestCase
 {
-    public function testPositiveDaysAddCorrectly()
+    public function testPositiveDaysAddCorrectly(): void
     {
         $daysToAdd = 5;
         $expectedDate = date('Y-m-d', strtotime('+' . $daysToAdd . ' days'));
         $this->assertEquals($expectedDate, Helper::addDays($daysToAdd));
     }
 
-    public function testZeroDaysReturnsSameDate()
+    public function testZeroDaysReturnsSameDate(): void
     {
         $daysToAdd = 0;
         $expectedDate = date('Y-m-d', strtotime('+' . $daysToAdd . ' days'));
         $this->assertEquals($expectedDate, Helper::addDays($daysToAdd));
     }
 
-    public function testNegativeDaysWorkCorrectly()
+    public function testNegativeDaysWorkCorrectly(): void
     {
         $daysToAdd = -5;
         $expectedDate = date('Y-m-d', strtotime($daysToAdd . ' days'));


### PR DESCRIPTION
This pull request includes several changes to the GitHub Actions workflow, `composer.json` dependencies, and PHP codebase. The main changes involve updating the CI configuration, modifying package dependencies, and enforcing stricter typing and standards.

### CI Configuration Updates:
* [`.github/workflows/code_style.yml`](diffhunk://#diff-067e99f23d269ddcaa0706cb015321c9ea937b802176b72cb66b260aa7ea089bL6-R69): Expanded the testing matrix to include PHP 8.3 and PHPUnit 10/11, added caching for Composer dependencies, and updated step names for clarity.

### Dependency Updates:
* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L27-R39): Updated PHP requirement to `^8.1`, added `phpstan/phpstan`, and updated `phpunit/phpunit` to support versions 10 and 11. [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L27-R39) [[2]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34R49-R51)

### Codebase Improvements:
* [`phpstan.neon`](diffhunk://#diff-0361f0c81f363476ddc6f44ab36fcbe66ee685d5f4c2a46b054924591544b766R1-R5): Added configuration for PHPStan with level 8 and specified paths for analysis.
* [`src/Helpers/Helper.php`](diffhunk://#diff-2bcdcf7e21fcdad4f14ce0d3caeb1ccba9e9e9718a83bbcc171da14c6a1ac5acR2-R9): Enforced strict types and added `Exception` import.
* [`tests/TestCase.php`](diffhunk://#diff-abf1fa77a19f720052b75bc802df0260157b9064d8c3c12a80794f01e9acc065L7-R9): Switched from `Orchestra\Testbench\TestCase` to `PHPUnit\Framework\TestCase` as the base test class.